### PR TITLE
(fix) Move minItems property up

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -14,10 +14,10 @@
     "images": {
       "title": "Bilder",
       "type": "array",
+      "minItems": 2,
       "items": {
         "title": "Bild",
         "type": "object",
-        "minItems": 2,
         "properties": {
           "file": {
             "type": "object",


### PR DESCRIPTION
This PR moves the `minItems` property one level up. Now the validation works as expected