### PR TITLE
Caption and credit shouldn't be required

### DIFF
--- a/resources/schema.json
+++ b/resources/schema.json
@@ -48,9 +48,7 @@
           }
         },
         "required": [
-          "label",
-          "caption",
-          "credit"
+          "label"
         ]
       }
     },


### PR DESCRIPTION
This PR makes the `caption` and `credit` fields not required