### PR TITLE
Load images markup from separate route

### DIFF
--- a/routes/rendering-info/web-images.js
+++ b/routes/rendering-info/web-images.js
@@ -1,0 +1,100 @@
+const Boom = require("boom");
+const Joi = require("joi");
+const fs = require("fs");
+const path = require("path");
+
+const viewsDir = path.join(__dirname, "/../../views/");
+
+const imageHelpers = require("../../helpers/images.js");
+
+// setup nunjucks environment
+const nunjucks = require("nunjucks");
+const nunjucksEnv = new nunjucks.Environment();
+
+// POSTed item will be validated against given schema
+// hence we fetch the JSON schema...
+const schemaString = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "../../resources/", "schema.json"), {
+    encoding: "utf-8"
+  })
+);
+const Ajv = require("ajv");
+const ajv = new Ajv();
+
+// add draft-04 support explicit
+ajv.addMetaSchema(require("ajv/lib/refs/json-schema-draft-04.json"));
+
+const validate = ajv.compile(schemaString);
+function validateAgainstSchema(item, options) {
+  if (validate(item)) {
+    return item;
+  } else {
+    throw Boom.badRequest(JSON.stringify(validate.errors));
+  }
+}
+
+async function validatePayload(payload, options, next) {
+  if (typeof payload !== "object") {
+    return next(Boom.badRequest(), payload);
+  }
+  if (typeof payload.item !== "object") {
+    return next(Boom.badRequest(), payload);
+  }
+  await validateAgainstSchema(payload.item, options);
+}
+
+module.exports = {
+  method: "POST",
+  path: "/rendering-info/web-images",
+  options: {
+    validate: {
+      options: {
+        allowUnknown: true
+      },
+      query: {
+        width: Joi.number().required(),
+        noCache: Joi.boolean(),
+        toolRuntimeConfig: Joi.object().optional()
+      },
+      payload: validatePayload
+    }
+  },
+  handler: async function(request, h) {
+    const item = request.payload.item;
+    item.images.map(image => {
+      image.urls = imageHelpers.getImageUrls(
+        image.file.key,
+        request.query.width
+      );
+    });
+
+    const tallestImage = item.images
+      .slice()
+      .sort((a, b) => {
+        const aspectRatioA = (a.file.height / a.file.width) * 100;
+        const aspectRationB = (b.file.height / b.file.width) * 100;
+        return aspectRatioA - aspectRationB;
+      })
+      .pop();
+
+    const context = {
+      item: item,
+      startImage: item.images[item.options.startImage],
+      paddingBottom: (tallestImage.file.height / tallestImage.file.width) * 100
+    };
+
+    let markup;
+    try {
+      markup = nunjucksEnv.render(viewsDir + "images.html", context);
+    } catch (e) {
+      console.error(e);
+      throw e;
+    }
+
+    const renderingInfo = {
+      markup: markup
+    };
+
+    return renderingInfo;
+  }
+};

--- a/routes/routes.js
+++ b/routes/routes.js
@@ -1,5 +1,6 @@
 module.exports = [
   require("./rendering-info/web.js"),
+  require("./rendering-info/web-images.js"),
   require("./stylesheet.js"),
   require("./script.js"),
   require("./health.js"),

--- a/views/images.html
+++ b/views/images.html
@@ -1,0 +1,43 @@
+{% if item.images.length > 2 %}
+<div>
+	<div class="q-imageslider-button-container">
+		{%- for image in item.images %}
+		<button type="button" class="q-imageslider-button">
+			<label class="q-imageslider-label s-font-sans s-font-note">
+				<span class="q-imageslider-label-text {% if loop.index0 == item.options.startImage %} s-color-gray-9 {% else %} s-color-gray-4 {% endif %}">{{
+					image.label }}</span>
+			</label>
+			<span class="q-imageslider-circle {% if loop.index0 == item.options.startImage %} s-color-primary-5 {% else %} s-color-gray-4 {% endif %}"></span>
+		</button>
+		{%- endfor %}
+	</div>
+	<div class="q-imageslider-bar s-color-gray-4"></div>
+</div>
+{% else %}
+<div class="s-input-switch s-input-switch--centered">
+	<input class="q-imageslider-switch" type="checkbox" {% if not(item.options.startImage===0 ) %} checked {% endif %}/> {%-
+	for image in item.images %}
+	<label>{{ image.label }}</label>
+	{%- endfor %}
+</div>
+{% endif %}
+<div class="q-imageslider-container">
+	<div class="q-imageslider-image-container" style="position:relative; padding-bottom: {{ paddingBottom }}%">
+		{%- for image in item.images %}
+		<picture>
+			<source type="image/webp" srcset="{{ image.urls.webp1x }} 1x, {{ image.urls.webp2x }} 2x">
+			<source srcset="{{ image.urls.image1x }} 1x, {{ image.urls.image2x }} 2x">
+			<img class="q-imageslider-image" data-imageIndex="{{ loop.index0 }}" style="position:absolute; display:block; width:100%; {% if loop.index0 === item.options.startImage %} opacity: 1; {% else %} opacity: 0; {% endif %}"
+			 src="{{ image.urls.image1x }}">
+		</picture>{%- endfor %}
+	</div>
+	<p class="q-imageslider-caption s-font-note s-font-note--light">
+		{{ startImage.caption }}
+		<span>
+			{%- if startImage.credit.text %} {%- if startImage.credit.link.url and startImage.credit.link.isValid %} (Bild: <a href="{{ startImage.credit.link.url }}"
+			 target="blank" rel="noopener noreferrer">{{ startImage.credit.text }}</a>) {%- else %} (Bild: {{ startImage.credit.text
+			}}) {%- endif %} {%- endif %}
+		</span>
+	</p>
+</div>
+</div>

--- a/views/imageslider.html
+++ b/views/imageslider.html
@@ -1,55 +1,5 @@
 <div id="{{ id }}" class="s-q-item q-imageslider" data-track-id="q-imageslider" style="opacity: 0;">
-  {%- include "./header.html" %}
-  {% if item.images.length > 2 %}
-  <div>
-    <div class="q-imageslider-button-container">
-      {%- for image in item.images %}
-      <button type="button" class="q-imageslider-button">
-        <label class="q-imageslider-label s-font-sans s-font-note">
-          <span class="q-imageslider-label-text {% if loop.index0 == item.options.startImage %} s-color-gray-9 {% else %} s-color-gray-4 {% endif %}">{{ image.label }}</span>
-        </label>
-        <span class="q-imageslider-circle {% if loop.index0 == item.options.startImage %} s-color-primary-5 {% else %} s-color-gray-4 {% endif %}"></span>
-      </button>
-      {%- endfor %}
-    </div>
-    <div class="q-imageslider-bar s-color-gray-4"></div>
-  </div>
-  {% else %}
-  <div class="s-input-switch s-input-switch--centered">
-    <input class="q-imageslider-switch" type="checkbox" {% if not(item.options.startImage === 0) %} checked {% endif %}/>
-    {%- for image in item.images %}
-    <label>{{ image.label }}</label>
-    {%- endfor %}
-  </div>
-  {% endif %}
-  <div class="q-imageslider-container">
-    <div class="q-imageslider-image-container" style="position:relative; padding-bottom: {{ paddingBottom }}%">
-      {%- for image in item.images %}
-        {%- if width %}
-        <picture>
-            <source type="image/webp" srcset="{{ image.urls.webp1x }} 1x, {{ image.urls.webp2x }} 2x">
-            <source srcset="{{ image.urls.image1x }} 1x, {{ image.urls.image2x }} 2x">
-            <img class="q-imageslider-image" data-imageIndex="{{ loop.index0 }}" style="position:absolute; display:block; width:100%; {% if loop.index0 === item.options.startImage %} opacity: 1; {% else %} opacity: 0; {% endif %}" src="{{ image.urls.image1x }}">
-        </picture>
-        {%- else %}
-        <picture data-imageIndex="{{ loop.index0 }}" data-startImage="{{item.options.startImage}}" data-imageKey="{{image.file.key}}">
-        </picture>
-        {%- endif %}
-      {%- endfor %}
-    </div>
-    <p class="q-imageslider-caption s-font-note s-font-note--light">
-      {{ startImage.caption }}
-      <span>
-      {%- if startImage.credit.text %}
-        {%- if startImage.credit.link.url and startImage.credit.link.isValid %}
-        (Bild: <a href="{{ startImage.credit.link.url }}" target="blank" rel="noopener noreferrer">{{ startImage.credit.text }}</a>)
-        {%- else %}
-        (Bild: {{ startImage.credit.text }})
-        {%- endif %}
-      {%- endif %}
-      </span>
-    </p>
-  </div>
-</div>
-  {%- include "./footer.html" %}
+	{%- include "./header.html" %}
+	<div class="q-imageslider-images">{{ imagesMarkup | safe }}</div>
+	{%- include "./footer.html" %}
 </div>


### PR DESCRIPTION
- This PR refactores the imageslider so that the images markup gets loaded from a separate route
- If the width is know upfront the `/web-images` route gets injected, otherwise the client makes a request on this route to get the images markup
- Most of the new code is copied from q-infographic
- This change is necessary to implement the size variants feature (https://github.com/nzzdev/Q-imageslider/issues/33)
- This branch is deployed on [test](https://q.st-test.nzz.ch/item/imageslider-10)