### PR TITLE
use image.url directly if no IMAGE_SERVICE_URL configured

### DIFF
--- a/helpers/images.js
+++ b/helpers/images.js
@@ -24,19 +24,23 @@ function getVariantForWidth(variants, width) {
   });
 }
 
-function getImageUrls(imageKey, width) {
+function getImageUrls(image, width) {
   return {
-    image1x: getImageUrl(imageKey, width, getFileExtension(imageKey)),
-    image2x: getImageUrl(imageKey, width * 2, getFileExtension(imageKey)),
-    webp1x: getImageUrl(imageKey, width, "webply"),
-    webp2x: getImageUrl(imageKey, width * 2, "webply")
+    image1x: getImageUrl(image, width, getFileExtension(image.key)),
+    image2x: getImageUrl(image, width * 2, getFileExtension(image.key)),
+    webp1x: getImageUrl(image, width, "webply"),
+    webp2x: getImageUrl(image, width * 2, "webply")
   };
 }
 
-function getImageUrl(imageKey, width, format) {
-  return process.env.IMAGE_SERVICE_URL.replace("{key}", imageKey)
-    .replace("{width}", width)
-    .replace("{format}", format);
+function getImageUrl(image, width, format) {
+  if (process.env.IMAGE_SERVICE_URL) {
+    return process.env.IMAGE_SERVICE_URL.replace("{key}", image.key)
+      .replace("{width}", width)
+      .replace("{format}", format);
+  } else {
+    return image.url;
+  }
 }
 
 function getFileExtension(imageKey) {

--- a/routes/rendering-info/web-images.js
+++ b/routes/rendering-info/web-images.js
@@ -95,7 +95,7 @@ module.exports = {
       if (variant) {
         // gets the necessary url strings to build the picture element
         image.urls = imageHelpers.getImageUrls(
-          variant.file.key,
+          variant.file,
           request.query.width
         );
       }


### PR DESCRIPTION
- In case no IMAGE_SERVICE_URL is configured, the image.url gets used directly
- This makes development without an image service easier
- deployed on test with no IMAGE_SERVICE_URL configured