### PR TITLE
Fix override sophie class

### DIFF
--- a/styles_src/default.scss
+++ b/styles_src/default.scss
@@ -108,6 +108,6 @@
   }
 }
 
-.s-input-switch {
+.q-imageslider-input-switch {
   margin-bottom: 10px;
 }

--- a/views/images.html
+++ b/views/images.html
@@ -14,7 +14,7 @@
 	<div class="q-imageslider-bar s-color-gray-4"></div>
 </div>
 {% else %}
-<div class="s-input-switch s-input-switch--centered">
+<div class="s-input-switch q-imageslider-input-switch s-input-switch--centered">
 	<input class="q-imageslider-switch" type="checkbox" {% if not(item.options.startImage===0 ) %} checked {% endif %}/> {%-
 	for image in item.images %}
 	<label>{{ image.label }}</label>


### PR DESCRIPTION
The sophie class s-switch-input is overwritten in the css and can therefore influence other graphics.

### Example:
https://q.st-staging.nzz.ch/item/imageslider-0